### PR TITLE
Update analytics-ios to custom v4.1.8 and firebase v10.21.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,29 +3,20 @@
     "pins": [
       {
         "package": "abseil",
-        "repositoryURL": "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+        "repositoryURL": "https://github.com/google/abseil-cpp-binary.git",
         "state": {
           "branch": null,
-          "revision": "d302de612e3d57c6f4afaf087da18fba8eac72a7",
-          "version": "0.20220203.1"
+          "revision": "df308b8b46607675f2b9ec8e569109008f9155ce",
+          "version": "1.2022062300.1"
         }
       },
       {
-        "package": "Segment",
-        "repositoryURL": "https://github.com/segmentio/analytics-ios.git",
+        "package": "AppCheck",
+        "repositoryURL": "https://github.com/google/app-check.git",
         "state": {
           "branch": null,
-          "revision": "fc64997865619f73bbab196c164f7845a13da110",
-          "version": "4.1.6"
-        }
-      },
-      {
-        "package": "BoringSSL-GRPC",
-        "repositoryURL": "https://github.com/firebase/boringssl-SwiftPM.git",
-        "state": {
-          "branch": null,
-          "revision": "79db6516894a932d0ddaff3b05b9da1e4f6c4069",
-          "version": "0.9.0"
+          "revision": "3e464dad87dad2d29bb29a97836789bf0f8f67d2",
+          "version": "10.18.1"
         }
       },
       {
@@ -33,8 +24,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "60f9a33e7084482df67b48e16f315f4f7a6f5da9",
-          "version": "10.6.0"
+          "revision": "be49849dcba96f2b5ee550d4eceb2c0fa27dade4",
+          "version": "10.22.1"
         }
       },
       {
@@ -42,8 +33,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "04351180d4c757c6c16127cb57b685fff9ef260b",
-          "version": "10.6.0"
+          "revision": "482cfa4e5880f0a29f66ecfd60c5a62af28bd1f0",
+          "version": "10.22.1"
         }
       },
       {
@@ -51,8 +42,8 @@
         "repositoryURL": "https://github.com/google/GoogleDataTransport.git",
         "state": {
           "branch": null,
-          "revision": "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
-          "version": "9.2.0"
+          "revision": "a637d318ae7ae246b02d7305121275bc75ed5565",
+          "version": "9.4.0"
         }
       },
       {
@@ -60,17 +51,17 @@
         "repositoryURL": "https://github.com/google/GoogleUtilities.git",
         "state": {
           "branch": null,
-          "revision": "6db6edb48bdd9943426562c7f042a5492de5ba3d",
-          "version": "7.10.0"
+          "revision": "26c898aed8bed13b8a63057ee26500abbbcb8d55",
+          "version": "7.13.1"
         }
       },
       {
         "package": "gRPC",
-        "repositoryURL": "https://github.com/grpc/grpc-ios.git",
+        "repositoryURL": "https://github.com/google/grpc-binary.git",
         "state": {
           "branch": null,
-          "revision": "2af4f6e9c2b18beae228f50b1198c641be859d2b",
-          "version": "1.44.2-grpc"
+          "revision": "ea4cb5cc0c39c732b85386263116d2e2fdbbdc61",
+          "version": "1.49.2"
         }
       },
       {
@@ -80,6 +71,15 @@
           "branch": null,
           "revision": "efda500b6d9858d38a76dbfbfa396bd644692e4a",
           "version": "3.0.0"
+        }
+      },
+      {
+        "package": "InteropForGoogle",
+        "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
+        "state": {
+          "branch": null,
+          "revision": "2d12673670417654f08f5f90fdd62926dc3a2648",
+          "version": "100.0.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/google/promises.git",
         "state": {
           "branch": null,
-          "revision": "46c1e6b5ac09d8f82c991061c659f67e573d425d",
-          "version": "2.1.0"
+          "revision": "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+          "version": "2.4.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "Segment",
+        "repositoryURL": "https://github.com/MyUNiDAYS/analytics-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "508ec32e151eae684240a2ed908b99d0a158c687",
+          "version": null
+        }
+      },
+      {
         "package": "AppCheck",
         "repositoryURL": "https://github.com/google/app-check.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/MyUNiDAYS/analytics-ios.git",
         "state": {
           "branch": null,
-          "revision": "508ec32e151eae684240a2ed908b99d0a158c687",
+          "revision": "76e4d86780e56c566c0c99a05841b4a4c8905f72",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
       .package(
         name: "Segment",
         url: "https://github.com/MyUNiDAYS/analytics-ios.git",
-        .revision("f73757a212d1c7f85b5e1ed3356f7011418302e3")
+        .revision("508ec32e151eae684240a2ed908b99d0a158c687")
       ),
       .package(
         name: "Firebase",

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,16 @@ let package = Package(
     platforms: [.iOS(.v11)],
     products: [.library(name: "SegmentFirebase", targets: ["SegmentFirebase"])],
     dependencies: [
-      .package(name: "Segment", url: "https://github.com/segmentio/analytics-ios.git", from: "4.1.6"),
-      .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.6.0"),
+      .package(
+        name: "Segment",
+        url: "https://github.com/MyUNiDAYS/analytics-ios.git",
+        .revision("f73757a212d1c7f85b5e1ed3356f7011418302e3")
+      ),
+      .package(
+        name: "Firebase",
+        url: "https://github.com/firebase/firebase-ios-sdk.git",
+        from: "10.21.0"
+      ),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
       .package(
         name: "Segment",
         url: "https://github.com/MyUNiDAYS/analytics-ios.git",
-        .revision("508ec32e151eae684240a2ed908b99d0a158c687")
+        .revision("76e4d86780e56c566c0c99a05841b4a4c8905f72")
       ),
       .package(
         name: "Firebase",

--- a/Segment-Firebase.podspec
+++ b/Segment-Firebase.podspec
@@ -25,9 +25,9 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'Analytics'
-  s.dependency 'Firebase', '~> 10.6.0'
-  s.dependency 'Firebase/Core', '~> 10.6.0'
-  s.dependency 'FirebaseAnalytics','~> 10.6.0'
+  s.dependency 'Firebase', '~> 10.21.0'
+  s.dependency 'Firebase/Core', '~> 10.21.0'
+  s.dependency 'FirebaseAnalytics','~> 10.21.0'
 
   s.subspec 'Core' do |core|
     #For users who only want the core Firebase package

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.h
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.h
@@ -4,13 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
-
-#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
-#import <Analytics/SEGIntegration.h>
-#else
-@import Segment;
-#endif
-
+#import <Segment/SEGIntegration.h>
 
 @interface SEGFirebaseIntegration : NSObject <SEGIntegration>
 

--- a/Segment-Firebase/Classes/SEGFirebaseIntegration.m
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegration.m
@@ -2,13 +2,7 @@
 
 #import <FirebaseCore/FirebaseCore.h>
 #import <FirebaseAnalytics/FirebaseAnalytics.h>
-
-#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
-#import <Analytics/SEGAnalyticsUtils.h>
-#else
-@import Segment;
-#endif
-
+#import <Segment/SEGAnalyticsUtils.h>
 
 @implementation SEGFirebaseIntegration
 

--- a/Segment-Firebase/Classes/SEGFirebaseIntegrationFactory.h
+++ b/Segment-Firebase/Classes/SEGFirebaseIntegrationFactory.h
@@ -1,11 +1,5 @@
 #import <Foundation/Foundation.h>
-
-#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
-#import <Analytics/SEGIntegrationFactory.h>
-#else
-@import Segment;
-#endif
-
+#import <Segment/SEGIntegrationFactory.h>
 
 @interface SEGFirebaseIntegrationFactory : NSObject <SEGIntegrationFactory>
 


### PR DESCRIPTION
Changes
- Use a custom version of analytics-ios that supports being used as a KMM dependency and has been upgraded to v4.1.8
- Bump the firebase to v10.21.0